### PR TITLE
Sort versions semantically

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -110,7 +110,15 @@ fetch('https://api.github.com/repos/dalathegreat/BE-Web-Installer/git/trees/main
     opt.textContent = 'Select...';
     sel.appendChild(opt);
 
-    Object.keys(images_by_version).sort().reverse().forEach(function(version) {
+    Object.keys(images_by_version).sort((a, b) => {
+        const pa = a.split('.').map(Number);
+        const pb = b.split('.').map(Number);
+        for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+            const diff = (pb[i] || 0) - (pa[i] || 0);
+            if (diff !== 0) return diff;
+        }
+        return 0;
+    }).forEach(function(version) {
         var opt = document.createElement('option');
         opt.value = version;
         opt.textContent = version;


### PR DESCRIPTION
This change splits each version string into numeric parts and compares them numerically, so 10.0.5 correctly ranks above 9.3.5. The || 0 handles version strings with different numbers of parts (e.g. 10.0 vs 10.0.2).