### PR TITLE
Bugfix: Strip v from number

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -111,8 +111,8 @@ fetch('https://api.github.com/repos/dalathegreat/BE-Web-Installer/git/trees/main
     sel.appendChild(opt);
 
     Object.keys(images_by_version).sort((a, b) => {
-        const pa = a.split('.').map(Number);
-        const pb = b.split('.').map(Number);
+        const pa = a.replace(/^v/, '').split('.').map(Number);
+        const pb = b.replace(/^v/, '').split('.').map(Number);
         for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
             const diff = (pb[i] || 0) - (pa[i] || 0);
             if (diff !== 0) return diff;


### PR DESCRIPTION
Led to incorrect sorting of versions

10.5.0
10.4.0
9.3.5
10.3.0
9.3.0
10.2.0
etc