### PR TITLE
Bugfix: Make Waveshare S3 detection work

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -153,7 +153,8 @@ img.addEventListener('change', function() {
     // document.body.appendChild(script);
     var uri = "https://raw.githubusercontent.com/dalathegreat/BE-Web-Installer/refs/heads/main/" + img.value;
 
-    const chipFamily = uri.indexOf("2CAN") > -1 ? "ESP32-S3" : "ESP32";
+    const ESP32_S3_BOARDS = ["2CAN", "S3"];
+    const chipFamily = ESP32_S3_BOARDS.some(id => uri.includes(id)) ? "ESP32-S3" : "ESP32";
 
     const manifest = {
         "name": "Battery Emulator",


### PR DESCRIPTION
## What
This PR makes the Waveshare installable via the BE Web installer

## Why
When trying to flash Waveshare using Web installer, it complains that S3 is not supported https://github.com/dalathegreat/Battery-Emulator/pull/2339#issuecomment-4529825952

<img width="1186" height="333" alt="image" src="https://github.com/user-attachments/assets/0c1c3fe9-cf27-45bc-8306-36abc54b5ef2" />

## How
We fix the detection logic for S3 chips, making it more future proof by checking if the board name contains "S3", and if so makes it compatible
